### PR TITLE
Relax Ruby requirement down to version 3.0.0 (from 3.1.0)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.0
   SuggestExtensions: false
   NewCops: enable
 

--- a/create_github_release_test.gemspec
+++ b/create_github_release_test.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Test for create-github-release"
   spec.homepage = "https://github.com/jcouball/create_github_release_test"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["allowed_push_host"] = "rubygems.org"
 

--- a/lib/create_github_release_test.rb
+++ b/lib/create_github_release_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "create_github_release_test/version"
 
+# The main module for this gem
 module CreateGithubReleaseTest
   class Error < StandardError; end
 

--- a/spec/create_github_release_test_spec.rb
+++ b/spec/create_github_release_test_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe CreateGithubReleaseTest do
     expect(CreateGithubReleaseTest::VERSION).not_to be nil
   end
 
-  describe '.hello' do
+  describe ".hello" do
     it 'should output "Hello, World!"' do
       expect { CreateGithubReleaseTest.hello }.to output("Hello, World!\n").to_stdout
     end
   end
 
-  describe '.goodbye' do
+  describe ".goodbye" do
     it 'should output "Goodbye, World!"' do
       expect { CreateGithubReleaseTest.goodbye }.to output("Goodbye, World!\n").to_stdout
     end


### PR DESCRIPTION
This PR does two things:

* Change the Ruby requirement from 3.1.0 to 3.0.0
*  Fix Rubocop offenses